### PR TITLE
Disable ESLint and configure Biome as default formatter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,18 @@
         "bradlc.vscode-tailwindcss",
         "humao.rest-client",
         "qwtel.sqlite-viewer"
-      ]
+      ],
+      "settings": {
+        "eslint.enable": false,
+        "[javascript][javascriptreact][typescript][typescriptreact]": {
+          "editor.formatOnSave": true,
+          "editor.defaultFormatter": "biomejs.biome",
+          "editor.codeActionsOnSave": {
+            "quickfix.biome": "explicit",
+            "source.organizeImports.biome": "explicit"
+          }
+        }
+      }
     }
   }
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.


### PR DESCRIPTION
This pull request disables ESLint and configures Biome as the default formatter for JavaScript, JavaScript React, TypeScript, and TypeScript React files. Additionally, it sets up code actions on save for Biome, including quick fixes and organizing imports.